### PR TITLE
Add JSON-LD Framing demonstration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.done.log
+_*
+__pycache__
+venv

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+#!/usr/bin/make -f
+
+# Portions of this file contributed by NIST are governed by the
+# following statement:
+#
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to Title 17 Section 105 of the
+# United States Code, this software is not subject to copyright
+# protection within the United States. NIST assumes no responsibility
+# whatsoever for its use by other parties, and makes no guarantees,
+# expressed or implied, about its quality, reliability, or any other
+# characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+SHELL := /bin/bash
+
+all: \
+  all-framing
+
+all-framing: \
+  .venv.done.log
+	$(MAKE) \
+	  --directory framing
+
+.venv.done.log: \
+  requirements.txt \
+  requirements-framing.txt
+	rm -rf venv
+	python3 -m venv venv
+	source venv/bin/activate && pip install --upgrade pip
+	source venv/bin/activate && pip install --requirement requirements.txt
+	source venv/bin/activate && pip install --requirement requirements-framing.txt
+	touch $@
+
+check: \
+  all
+
+clean:
+	@$(MAKE) \
+	  --directory framing \
+	  clean

--- a/README.md
+++ b/README.md
@@ -49,3 +49,8 @@ This script processes the input data in batches and serializes the output to a .
 
 
 Github runs an action upon commit (`.github/workflows/run-serialization.yml`) that orchestrates this small system to produce validated CASE/UCO .jsonld
+
+
+## Licensing
+
+Portions of this repository contributed by NIST are governed by the [NIST Software Licensing Statement](THIRD_PARTY_LICENSES.md#nist-software-licensing-statement).

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,39 @@
+Portions of this repository contributed by NIST are governed by
+the following license.
+
+
+# NIST Software Licensing Statement
+
+NIST-developed software is provided by NIST as a public service.
+You may use, copy, and distribute copies of the software in any
+medium, provided that you keep intact this entire notice. You may
+improve, modify, and create derivative works of the software or
+any portion of the software, and you may copy and distribute such
+modifications or works. Modified works should carry a notice
+stating that you changed the software and should note the date
+and nature of any such change. Please explicitly acknowledge the
+National Institute of Standards and Technology as the source of
+the software.
+
+NIST-developed software is expressly provided "AS IS." NIST MAKES
+NO WARRANTY OF ANY KIND, EXPRESS, IMPLIED, IN FACT, OR ARISING BY
+OPERATION OF LAW, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+NON-INFRINGEMENT, AND DATA ACCURACY. NIST NEITHER REPRESENTS NOR
+WARRANTS THAT THE OPERATION OF THE SOFTWARE WILL BE UNINTERRUPTED
+OR ERROR-FREE, OR THAT ANY DEFECTS WILL BE CORRECTED. NIST DOES
+NOT WARRANT OR MAKE ANY REPRESENTATIONS REGARDING THE USE OF THE
+SOFTWARE OR THE RESULTS THEREOF, INCLUDING BUT NOT LIMITED TO THE
+CORRECTNESS, ACCURACY, RELIABILITY, OR USEFULNESS OF THE
+SOFTWARE.
+
+You are solely responsible for determining the appropriateness of
+using and distributing the software and you assume all risks
+associated with its use, including but not limited to the risks
+and costs of program errors, compliance with applicable laws,
+damage to or loss of data, programs or equipment, and the
+unavailability or interruption of operation. This software is not
+intended to be used in any situation where a failure could cause
+risk of injury or damage to property. The software developed by
+NIST employees is not subject to copyright protection within the
+United States.

--- a/framing/Makefile
+++ b/framing/Makefile
@@ -1,0 +1,73 @@
+#!/usr/bin/make -f
+
+# Portions of this file contributed by NIST are governed by the
+# following statement:
+#
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to Title 17 Section 105 of the
+# United States Code, this software is not subject to copyright
+# protection within the United States. NIST assumes no responsibility
+# whatsoever for its use by other parties, and makes no guarantees,
+# expressed or implied, about its quality, reliability, or any other
+# characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+SHELL := /bin/bash
+
+top_srcdir := ..
+
+all: \
+  shared_hashes_framed.jsonld.case_validate.done.log \
+  selfie_framed.jsonld.case_validate.done.log
+
+%.jsonld.case_validate.done.log: \
+  %.jsonld \
+  $(top_srcdir)/.venv.done.log
+	source $(top_srcdir)/venv/bin/activate \
+	  && case_validate \
+	    --allow-infos \
+	    $<
+	touch $@
+
+.mypy.done.log: \
+  $(top_srcdir)/.venv.done.log \
+  frame.py
+	source $(top_srcdir)/venv/bin/activate \
+	  && mypy --strict frame.py
+	touch $@
+
+check: \
+  all
+
+clean:
+	@rm -f \
+	  *.case_validate.done.log \
+	  *_framed.jsonld
+
+selfie_framed.jsonld: \
+  .mypy.done.log \
+  case_file_frame.jsonld \
+  selfie_flattened.jsonld.case_validate.done.log
+	source $(top_srcdir)/venv/bin/activate \
+	  && python3 frame.py \
+	    __$@ \
+	    case_file_frame.jsonld \
+	    selfie_flattened.jsonld
+	python3 -m json.tool __$@ _$@
+	rm __$@
+	mv _$@ $@
+
+shared_hashes_framed.jsonld: \
+  .mypy.done.log \
+  case_file_frame.jsonld \
+  shared_hashes_flattened.jsonld.case_validate.done.log
+	source $(top_srcdir)/venv/bin/activate \
+	  && python3 frame.py \
+	    __$@ \
+	    case_file_frame.jsonld \
+	    shared_hashes_flattened.jsonld
+	python3 -m json.tool __$@ _$@
+	rm __$@
+	mv _$@ $@

--- a/framing/README.md
+++ b/framing/README.md
@@ -1,0 +1,39 @@
+# JSON-LD framing
+
+This directory demonstrates [JSON-LD Framing](https://www.w3.org/TR/json-ld11-framing/).
+
+
+## CASE/UCO File demonstration
+
+A demonstration is provided to re-shape all `uco-observable:File`s found in a graph.
+
+* `frame.py` - A minimal wrapper around a Framing implementation[^1].
+* `case_file_frame.jsonld` - A JSON-LD Frame describing selection criteria and output form.  This frame selects nodes typed as `uco-observable:File` and inlines `uco-types:Hash`es and the linking `uco-observable:ContentDataFacet`s.
+* `two_files_flattened.jsonld` - An input graph, containing:
+   - Nodes that should be included in the framed results (four `uco-observable:File`s and their linked nodes).
+   - Nodes that should be included in the framed results, even lacking links to hashes (two `uco-observable:File`s).
+   - Nodes that should be included *with full repetition* in the framed results (a shared `uco-types:Hash`).
+   - Nodes that should be included in the framed results after subclass entailment (a `uco-observable:ArchiveFile` that is not also explicitly typed as a `uco-observable:File`, though the typing is implicit from the ontology).
+   - Nodes that will not be included in the framed results (a `uco-core:Bundle`, and a `uco-types:Hash` not associated with one of the included `File`s).
+   - Nodes that attempt to induce an infinite reference loop by linking to each other (two `uco-observable:File`s form one loop).  The attempt does not succeed.
+* `two_files_framed.jsonld` - The output graph.
+
+
+## Longer loop demonstration
+
+This demonstration re-uses `frame.py` and `case_file_frame.jsonld` from above.
+
+* `selfie_flattened.jsonld` - An input graph, denoting a "selfie" picture file.  Records are kept under a certain usage of FOAF and PROV-O.  The loop demonstrates multiple paths to return to the same file.
+
+```mermaid
+flowchart TD
+kb_Selfie_1[kb:Selfie-1]
+kb_Person_1[kb:Person-1]
+    
+kb_Selfie_1 --foaf:depicts--> kb_Person_1
+kb_Selfie_1 --prov:wasGeneratedBy--> kb_Person_1
+kb_Person_1 --foaf:depiction--> kb_Selfie_1
+kb_Person_1 --prov:generated--> kb_Selfie_1
+```
+
+[^1]: Participation by NIST in the creation of the documentation of mentioned software is not intended to imply a recommendation or endorsement by the National Institute of Standards and Technology, nor is it intended to imply that any specific software is necessarily the best available for the purpose.

--- a/framing/case_file_frame.jsonld
+++ b/framing/case_file_frame.jsonld
@@ -1,0 +1,18 @@
+{
+    "@context": {
+        "kb": "http://example.org/kb/",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/",
+        "uco-observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
+        "uco-types": "https://ontology.unifiedcyberontology.org/uco/types/",
+        "uco-vocabulary": "https://ontology.unifiedcyberontology.org/uco/vocabulary/",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
+    },
+    "@type": "uco-observable:File",
+    "uco-core:hasFacet": {
+        "@type": "uco-observable:ContentDataFacet",
+        "uco-observable:hash": {
+            "@type": "uco-types:Hash"
+        }
+    }
+}

--- a/framing/frame.py
+++ b/framing/frame.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+# Portions of this file contributed by NIST are governed by the
+# following statement:
+#
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to Title 17 Section 105 of the
+# United States Code, this software is not subject to copyright
+# protection within the United States. NIST assumes no responsibility
+# whatsoever for its use by other parties, and makes no guarantees,
+# expressed or implied, about its quality, reliability, or any other
+# characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+import argparse
+import json
+import sys
+
+import pyld.jsonld  # type: ignore
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("framed_jsonld", help="Output graph")
+    parser.add_argument("frame_jsonld", help="Frame file")
+    parser.add_argument("data_jsonld", help="Input JSON-LD graph")
+    args = parser.parse_args()
+    with open(args.frame_jsonld, "r") as in_fh:
+        frame = json.load(in_fh)
+    with open(args.data_jsonld, "r") as in_fh:
+        json_input = json.load(in_fh)
+    with open(args.framed_jsonld, "w") as out_fh:
+        framed = pyld.jsonld.frame(json_input, frame)
+        print(json.dumps(framed), file=out_fh)
+
+
+if __name__ == "__main__":
+    main()

--- a/framing/selfie_flattened.jsonld
+++ b/framing/selfie_flattened.jsonld
@@ -1,0 +1,42 @@
+{
+    "@context": {
+        "kb": "http://example.org/kb/",
+        "foaf": "http://xmlns.com/foaf/0.1/",
+        "prov": "http://www.w3.org/ns/prov#",
+
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "uco-identity": "https://ontology.unifiedcyberontology.org/uco/identity/",
+        "uco-observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
+    },
+    "@graph": [
+        {
+            "@id": "kb:Person-1",
+            "@type": [
+                "foaf:Person",
+                "prov:Person",
+                "uco-identity:Person"
+            ],
+            "foaf:depiction": {
+                "@id": "kb:Selfie-1"
+            },
+            "prov:generated": {
+                "@id": "kb:Selfie-1"
+            }
+        },
+        {
+            "@id": "kb:Selfie-1",
+            "@type": [
+                "foaf:Image",
+                "prov:Entity",
+                "uco-observable:File"
+            ],
+            "foaf:depicts": {
+                "@id": "kb:Person-1"
+            },
+            "prov:wasGeneratedBy": {
+                "@id": "kb:Person-1"
+            }
+        }
+    ]
+}

--- a/framing/selfie_framed.jsonld
+++ b/framing/selfie_framed.jsonld
@@ -1,0 +1,35 @@
+{
+    "@context": {
+        "kb": "http://example.org/kb/",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/",
+        "uco-observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
+        "uco-types": "https://ontology.unifiedcyberontology.org/uco/types/",
+        "uco-vocabulary": "https://ontology.unifiedcyberontology.org/uco/vocabulary/",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
+    },
+    "@id": "kb:Selfie-1",
+    "@type": [
+        "http://xmlns.com/foaf/0.1/Image",
+        "http://www.w3.org/ns/prov#Entity",
+        "uco-observable:File"
+    ],
+    "http://www.w3.org/ns/prov#wasGeneratedBy": {
+        "@id": "kb:Person-1",
+        "@type": [
+            "http://xmlns.com/foaf/0.1/Person",
+            "http://www.w3.org/ns/prov#Person",
+            "https://ontology.unifiedcyberontology.org/uco/identity/Person"
+        ],
+        "http://www.w3.org/ns/prov#generated": {
+            "@id": "kb:Selfie-1"
+        },
+        "http://xmlns.com/foaf/0.1/depiction": {
+            "@id": "kb:Selfie-1"
+        }
+    },
+    "http://xmlns.com/foaf/0.1/depicts": {
+        "@id": "kb:Person-1"
+    },
+    "uco-core:hasFacet": null
+}

--- a/framing/shared_hashes_flattened.jsonld
+++ b/framing/shared_hashes_flattened.jsonld
@@ -1,0 +1,117 @@
+{
+    "@context": {
+        "kb": "http://example.org/kb/",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/",
+        "uco-observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
+        "uco-types": "https://ontology.unifiedcyberontology.org/uco/types/",
+        "uco-vocabulary": "https://ontology.unifiedcyberontology.org/uco/vocabulary/",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
+    },
+    "@graph": [
+        {
+            "@id": "kb:ArchiveFile-b5d685d6-ab6f-42c5-9d96-9bed05d07db5",
+            "@type": "uco-observable:ArchiveFile",
+            "rdfs:comment": "This file has a different hash from the two files in the bundle.  The technical purpose of this file is showing when filtering decisions occur.  This node will not be included in the results unless type expansion occurs (i.e., the superclass :File is added through RDFS or OWL expansion before framing).",
+            "uco-core:hasFacet": {
+                "@id": "kb:ContentDataFacet-e61b068e-a011-40a7-8462-d84b8a71acf6"
+            }
+        },
+        {
+            "@id": "kb:Bundle-3e08eb6e-de45-40f7-99e6-007a671c30e0",
+            "@type": "uco-core:Bundle",
+            "rdfs:comment": "This bundle groups two files that have a matching hash.  The technical purpose of this bundle is showing when inlining decisions occur.  This node will not be included in the results.  (Empty frame wildcard usage not yet explored.)",
+            "rdfs:seeAlso": {"@id": "https://www.w3.org/TR/json-ld11-framing/#empty-frame-0"},
+            "uco-core:object": [
+                {
+                    "@id": "kb:File-31a27433-e5aa-43d8-b4c5-e6102492ebcf"
+                },
+                {
+                    "@id": "kb:File-fc4b17d1-9c23-4791-8324-d2299cf5ecb1"
+                }
+            ]
+        },
+        {
+            "@id": "kb:ContentDataFacet-22e6ec48-9edc-45e2-befa-b6c98847fd16",
+            "@type": "uco-observable:ContentDataFacet",
+            "rdfs:comment": "This facet is expected to have an inlined hash.",
+            "uco-observable:hash": {
+                "@id": "kb:Hash-82079c48-93b9-40e8-89d1-53c496bf311d"
+            }
+        },
+        {
+            "@id": "kb:ContentDataFacet-921f83ab-bfc1-4656-9380-9b02e2410f2f",
+            "@type": "uco-observable:ContentDataFacet",
+            "rdfs:comment": "This facet is expected to have an inlined hash.",
+            "uco-observable:hash": {
+                "@id": "kb:Hash-82079c48-93b9-40e8-89d1-53c496bf311d"
+            }
+        },
+        {
+            "@id": "kb:ContentDataFacet-e61b068e-a011-40a7-8462-d84b8a71acf6",
+            "@type": "uco-observable:ContentDataFacet",
+            "rdfs:comment": "This facet will be dropped unless type expansion occurs on the ArchiveFile node.",
+            "uco-observable:hash": {
+                "@id": "kb:Hash-b05ed35d-3f1e-440f-aea6-77fd9d07be38"
+            }
+        },
+        {
+            "@id": "kb:File-31a27433-e5aa-43d8-b4c5-e6102492ebcf",
+            "@type": "uco-observable:File",
+            "rdfs:comment": "This file is expected to have an inlined ContentDataFacet.",
+            "uco-core:hasFacet": {
+                "@id": "kb:ContentDataFacet-22e6ec48-9edc-45e2-befa-b6c98847fd16"
+            }
+        },
+        {
+            "@id": "kb:File-cd93ddfc-ded1-42dd-825c-66e36cc5cc54",
+            "@type": "uco-observable:File",
+            "rdfs:comment": "This file node is expected to attempt, but not succeed at, inducing an infinite loop of node-inlines via rdfs:seeAlso with a 'partnered' file.",
+            "rdfs:seeAlso": {
+                "@id": "kb:File-ea6b3bb4-5932-4e00-8740-086d78e4125f"
+            }
+        },
+        {
+            "@id": "kb:File-ea6b3bb4-5932-4e00-8740-086d78e4125f",
+            "@type": "uco-observable:File",
+            "rdfs:comment": "This file node is a 'partner' file in an attempted inifite node-inlining loop using rdfs:seeAlso.",
+            "rdfs:seeAlso": {
+                "@id": "kb:File-cd93ddfc-ded1-42dd-825c-66e36cc5cc54"
+            }
+        },
+        {
+            "@id": "kb:File-fc4b17d1-9c23-4791-8324-d2299cf5ecb1",
+            "@type": "uco-observable:File",
+            "rdfs:comment": "This file is expected to have an inlined ContentDataFacet.",
+            "uco-core:hasFacet": {
+                "@id": "kb:ContentDataFacet-921f83ab-bfc1-4656-9380-9b02e2410f2f"
+            }
+        },
+        {
+            "@id": "kb:Hash-82079c48-93b9-40e8-89d1-53c496bf311d",
+            "@type": "uco-types:Hash",
+            "rdfs:comment": "This hash is expected to appear fully inlined in two nodes.",
+            "uco-types:hashMethod": {
+                "@type": "uco-vocabulary:HashNameVocab",
+                "@value": "SHA256"
+            },
+            "uco-types:hashValue": {
+                "@type": "xsd:hexBinary",
+                "@value": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+            }
+        },
+        {
+            "@id": "kb:Hash-b05ed35d-3f1e-440f-aea6-77fd9d07be38",
+            "@type": "uco-types:Hash",
+            "rdfs:comment": "This hash will be dropped unless type expansion occurs on the ArchiveFile node.",
+            "uco-types:hashMethod": {
+                "@type": "uco-vocabulary:HashNameVocab",
+                "@value": "SHA256"
+            },
+            "uco-types:hashValue": {
+                "@type": "xsd:hexBinary",
+                "@value": "762069bc07a6e1b5df123a5ae7bd91c10daa04694fbaa17fba0cd6a8dcce8f22"
+            }
+        }
+    ]
+}

--- a/framing/shared_hashes_framed.jsonld
+++ b/framing/shared_hashes_framed.jsonld
@@ -1,0 +1,87 @@
+{
+    "@context": {
+        "kb": "http://example.org/kb/",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "uco-core": "https://ontology.unifiedcyberontology.org/uco/core/",
+        "uco-observable": "https://ontology.unifiedcyberontology.org/uco/observable/",
+        "uco-types": "https://ontology.unifiedcyberontology.org/uco/types/",
+        "uco-vocabulary": "https://ontology.unifiedcyberontology.org/uco/vocabulary/",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
+    },
+    "@graph": [
+        {
+            "@id": "kb:File-31a27433-e5aa-43d8-b4c5-e6102492ebcf",
+            "@type": "uco-observable:File",
+            "rdfs:comment": "This file is expected to have an inlined ContentDataFacet.",
+            "uco-core:hasFacet": {
+                "@id": "kb:ContentDataFacet-22e6ec48-9edc-45e2-befa-b6c98847fd16",
+                "@type": "uco-observable:ContentDataFacet",
+                "rdfs:comment": "This facet is expected to have an inlined hash.",
+                "uco-observable:hash": {
+                    "@id": "kb:Hash-82079c48-93b9-40e8-89d1-53c496bf311d",
+                    "@type": "uco-types:Hash",
+                    "rdfs:comment": "This hash is expected to appear fully inlined in two nodes.",
+                    "uco-types:hashMethod": {
+                        "@type": "uco-vocabulary:HashNameVocab",
+                        "@value": "SHA256"
+                    },
+                    "uco-types:hashValue": {
+                        "@type": "xsd:hexBinary",
+                        "@value": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+                    }
+                }
+            }
+        },
+        {
+            "@id": "kb:File-cd93ddfc-ded1-42dd-825c-66e36cc5cc54",
+            "@type": "uco-observable:File",
+            "rdfs:comment": "This file node is expected to attempt, but not succeed at, inducing an infinite loop of node-inlines via rdfs:seeAlso with a 'partnered' file.",
+            "rdfs:seeAlso": {
+                "@id": "kb:File-ea6b3bb4-5932-4e00-8740-086d78e4125f",
+                "@type": "uco-observable:File",
+                "rdfs:comment": "This file node is a 'partner' file in an attempted inifite node-inlining loop using rdfs:seeAlso.",
+                "rdfs:seeAlso": {
+                    "@id": "kb:File-cd93ddfc-ded1-42dd-825c-66e36cc5cc54"
+                }
+            },
+            "uco-core:hasFacet": null
+        },
+        {
+            "@id": "kb:File-ea6b3bb4-5932-4e00-8740-086d78e4125f",
+            "@type": "uco-observable:File",
+            "rdfs:comment": "This file node is a 'partner' file in an attempted inifite node-inlining loop using rdfs:seeAlso.",
+            "rdfs:seeAlso": {
+                "@id": "kb:File-cd93ddfc-ded1-42dd-825c-66e36cc5cc54",
+                "@type": "uco-observable:File",
+                "rdfs:comment": "This file node is expected to attempt, but not succeed at, inducing an infinite loop of node-inlines via rdfs:seeAlso with a 'partnered' file.",
+                "rdfs:seeAlso": {
+                    "@id": "kb:File-ea6b3bb4-5932-4e00-8740-086d78e4125f"
+                }
+            },
+            "uco-core:hasFacet": null
+        },
+        {
+            "@id": "kb:File-fc4b17d1-9c23-4791-8324-d2299cf5ecb1",
+            "@type": "uco-observable:File",
+            "rdfs:comment": "This file is expected to have an inlined ContentDataFacet.",
+            "uco-core:hasFacet": {
+                "@id": "kb:ContentDataFacet-921f83ab-bfc1-4656-9380-9b02e2410f2f",
+                "@type": "uco-observable:ContentDataFacet",
+                "rdfs:comment": "This facet is expected to have an inlined hash.",
+                "uco-observable:hash": {
+                    "@id": "kb:Hash-82079c48-93b9-40e8-89d1-53c496bf311d",
+                    "@type": "uco-types:Hash",
+                    "rdfs:comment": "This hash is expected to appear fully inlined in two nodes.",
+                    "uco-types:hashMethod": {
+                        "@type": "uco-vocabulary:HashNameVocab",
+                        "@value": "SHA256"
+                    },
+                    "uco-types:hashValue": {
+                        "@type": "xsd:hexBinary",
+                        "@value": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/requirements-framing.txt
+++ b/requirements-framing.txt
@@ -1,0 +1,3 @@
+PyLD
+case-utils
+mypy


### PR DESCRIPTION
This Pull Request adds a demonstration of [JSON-LD Framing](https://www.w3.org/TR/json-ld11-framing), as part of inspecting strategies around iterative parsing of CASE graphs.

Note that this is a 3-patch series, with the first patch updating licensing.

Some `make`[^1] usage is added for the benefit of offline development, but is not added to the CI process.  I leave integrating that to the project owner, and it can happen in this PR or a future PR.

[^1]: Disclaimer: Participation by NIST in the creation of the documentation of mentioned software is not intended to imply a recommendation or endorsement by the National Institute of Standards and Technology, nor is it intended to imply that any specific software is necessarily the best available for the purpose.